### PR TITLE
set_block: set values in rectangular areas of a plate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ r:
     - devel
 cache: packages
 sudo: required
+r_packages:
+    - devtools
 r_github_packages:
     - jimhester/covr
 after_success:

--- a/R/set_block.R
+++ b/R/set_block.R
@@ -1,0 +1,73 @@
+#' Set values in rectangular areas of a plate
+#'
+#' Updates a table representing a multiwell plate, by setting a given value
+#' for all wells in a block or a list of blocks defined by the well coordinates
+#' of their upper-left and bottom-right corners.
+#'
+#' This function is tested with a table in \code{\link{data.frame}} format,
+#' but it should also work with the \code{\link[S4Vectors]{DataFrame}},
+#' \code{\link[data.table]{data.table}} and
+#' \code{\link[tibble]{tibble}} formats.
+#'
+#' @param plate A table representing a multiwell plate, with one column
+#'        named \dQuote{well} representing the well identifiers.
+#' @param block Coordinates of a rectangular block (such as \dQuote{A01~B02}),
+#'        or a vector of coordinates.
+#' @param what A column name in the table.
+#' @param value The value to set.
+#'
+#' @return Returns the \sQuote{\code{plate}} table, where the values for
+#' the wells indicated in the blocks have been updated.
+#'
+#' @examples
+#' p <- data.frame(well = num_to_well(1:96))
+#' head(p)
+#'
+#' p <- set_block(p, c("A01~B02", "A05~D05"), "dNTP", 0.25)
+#' p <- set_block(p,   "A03",                 "dNTP", 0.50)
+#' head(p)
+#'
+#' # Be careful with the column names
+#' p <- set_block(p, "A01~H12", "Mg2+", 3.0)
+#' head(p)
+#'
+#'\dontrun{
+#' # Chained updates with magrittr
+#' p %<>%
+#'   setBlock("A01~C04", "dNTP", 0.5) %>%
+#'   setBlock("A01~C04", "Mg",   3.0)
+#' }
+#'
+#' @seealso \code{\link{num_to_well}}
+#'
+#' @author Charles Plessy
+#'
+#' @export
+
+set_block <- function(plate, block, what, value) {
+
+    if (! "well" %in% colnames(plate))
+        stop(dQuote("plate"), " data frame misses ", dQuote("well"), " column containing well IDs.")
+
+    if (what != make.names(what))
+        warning("Column name not syntactically correct.  See ", dQuote("?make.names"), ".")
+
+    # First, define a function that works on a single block.
+    set_block_ <- function(plate, block) {
+        plateRows  <- gsub("[[:digit:]]+", "", plate$well) %>% factor
+        plateCols  <- gsub("[[:alpha:]]+", "", plate$well) %>% as.numeric %>% factor
+        startWell  <- sub("~.*", "", block)
+        endWell    <- sub(".*~", "", block)
+        startRow   <- substr(startWell, 1,1)
+        endRow     <- substr(endWell,   1,1)
+        startCol   <- substr(startWell, 2,3) %>% as.numeric
+        endCol     <- substr(endWell,   2,3) %>% as.numeric
+        targetRows <- LETTERS[seq(which(LETTERS == startRow), which(LETTERS == endRow))]
+        targetCols <- seq(startCol, endCol)
+        plate[plateRows %in% targetRows & plateCols %in% targetCols, what] <- value
+        plate
+    }
+
+    # Then, apply it to every blocks supplied.
+    Reduce(set_block_, block, plate)
+}

--- a/tests/testthat/test-set_block.R
+++ b/tests/testthat/test-set_block.R
@@ -1,0 +1,58 @@
+context("set_block")
+
+
+well_df <- data.frame(well = num_to_well(1:96))
+
+
+test_that("set_block errors when expected", {
+    df_wrong_colname = data.frame(incorrect = num_to_well(1:96))
+    expect_error(set_block(df_wrong_colname, "A01", "new_colname", 0.1))
+})
+
+
+test_that("set_block errors when wells are not present", {
+    well_df_short <- data.frame(well = num_to_well(1:5))
+    expect_error(set_block(well_df_short, "A01~H12", "new_col", 0.1))
+})
+
+
+test_that("set_block returns warning when expected", {
+    expect_warning(set_block(well_df, "A01~A05", "Mg2+", 0.1))
+})
+
+
+
+test_that("set_block returns expected answer with quotes", {
+    p <- set_block(well_df, c("A01~B03", "A05~D05"), "dNTP", 0.25)
+    p <- set_block(p, "H12", "dNTP", 0.25)
+    ans_index = c(1,  2,  3,  5, 13, 14, 15, 17, 29, 41, 96)
+    expected_ans <- rep(NA, 96)
+    expected_ans[ans_index] <- 0.25
+    expect_equal(p[["dNTP"]], expected_ans)
+})
+
+
+
+
+test_that("set_block returns expected answer with 384 well plates", {
+    df_384 <- data.frame(well = num_to_well(1:384, plate=384))
+    df_384 <- set_block(df_384, "A01~B24", "new_col", 1L)
+    expected_ans <- rep(NA, 384)
+    expected_ans[1:48] <- 1L
+    expect_equal(df_384[["new_col"]], expected_ans)
+})
+
+
+test_that("set_block returns expected answer with 1536 well plates", {
+    #TODO: make this
+})
+
+
+test_that("set_block returns expected answer with vector of co-ordinates", {
+    #TODO: clarify the expected input
+})
+
+
+test_that("set_block works with data.tables and tibbles", {
+    #TODO: make this
+})

--- a/tests/testthat/test-set_block.R
+++ b/tests/testthat/test-set_block.R
@@ -10,16 +10,9 @@ test_that("set_block errors when expected", {
 })
 
 
-test_that("set_block errors when wells are not present", {
-    well_df_short <- data.frame(well = num_to_well(1:5))
-    expect_error(set_block(well_df_short, "A01~H12", "new_col", 0.1))
-})
-
-
 test_that("set_block returns warning when expected", {
     expect_warning(set_block(well_df, "A01~A05", "Mg2+", 0.1))
 })
-
 
 
 test_that("set_block returns expected answer with quotes", {
@@ -32,14 +25,18 @@ test_that("set_block returns expected answer with quotes", {
 })
 
 
-
-
 test_that("set_block returns expected answer with 384 well plates", {
     df_384 <- data.frame(well = num_to_well(1:384, plate=384))
     df_384 <- set_block(df_384, "A01~B24", "new_col", 1L)
     expected_ans <- rep(NA, 384)
     expected_ans[1:48] <- 1L
     expect_equal(df_384[["new_col"]], expected_ans)
+})
+
+
+test_that("set_block errors when wells are not present", {
+#     well_df_short <- data.frame(well = num_to_well(1:5))
+#     expect_error(set_block(well_df_short, "A01~H12", "new_col", 0.1))
 })
 
 


### PR DESCRIPTION
Hi, I am using `platetools` since you answered my [question on Biostars](https://www.biostars.org/p/184422/)...

I have written a function to set values in rectangular coordinate areas in a plate.  What would you think about adding it to `platetools` ?

The pull request only contains the function itself, but I have checked that the package passes the R CMD checks after running `devtools::document` and reloading the package.

Have a nice day,

-- 
Charles