### PR TITLE
Simple warning message change

### DIFF
--- a/R/check_plate_input.R
+++ b/R/check_plate_input.R
@@ -5,11 +5,11 @@
 
 check_plate_input <- function(well, plate) {
     if (length(well) > plate){
-        warning(paste("Warning: Invalid plate selection. The well data given (",length(well),") has more entries then number of wells in the selected plate (",plate,").\nAre you sure argument 'plate' is correct for the number of wells in your data?\nnote: Default is a 96-well plate.",
+        warning(paste("Warning: Invalid plate selection. The well data given (",length(well),") has more entries then number of wells in the selected plate (",plate,").\nAre you sure argument 'plate' is correct for the number of wells in your data?\nnote: Default is a 96-well plate."),
                 call. = FALSE)
     }
     if (plate > 2 * length(well)){
-        warning("Warning: Your well label count (",length(well),") covers less than half the selected plate(",plate,").\nAre you sure argument 'plate' is correct for the number of wells in your data?\nnote: Default is a 96-well plate.",
+        warning(paste("Warning: Your well label count (",length(well),") covers less than half the selected plate(",plate,").\nAre you sure argument 'plate' is correct for the number of wells in your data?\nnote: Default is a 96-well plate."),
                 call. = FALSE)
     }
 }

--- a/R/check_plate_input.R
+++ b/R/check_plate_input.R
@@ -5,11 +5,11 @@
 
 check_plate_input <- function(well, plate) {
     if (length(well) > plate){
-        warning("Invalid plate selection. The data given has more rows then number of wells.\nAre you sure argument 'plate' is correct for the number of wells in your data?\nnote: Default is a 96-well plate.",
+        warning(paste("Warning: Invalid plate selection. The well data given (",length(well),") has more entries then number of wells in the selected plate (",plate,").\nAre you sure argument 'plate' is correct for the number of wells in your data?\nnote: Default is a 96-well plate.",
                 call. = FALSE)
     }
     if (plate > 2 * length(well)){
-        warning("Invalid plate selection. The data given has more rows then number of wells.\nAre you sure argument 'plate' is correct for the number of wells in your data?\nnote: Default is a 96-well plate.",
+        warning("Warning: Your well label count (",length(well),") covers less than half the selected plate(",plate,").\nAre you sure argument 'plate' is correct for the number of wells in your data?\nnote: Default is a 96-well plate.",
                 call. = FALSE)
     }
 }


### PR DESCRIPTION
Thanks for the great tool! I just ran into a weird error, where platetools indicated I had too many wells for the plate I specified. This seemed a bit weird as I had just a few wells. It ended up being the second condition in the code below, which could use a better warning. You could drop my redundant warning text, but I like it being super clear to the user that this is a warning. Let me know what you think.