### PR TITLE
Update test expectations

### DIFF
--- a/tests/testthat/test-plot_wrapper.R
+++ b/tests/testthat/test-plot_wrapper.R
@@ -30,11 +30,8 @@ test_that("returns ggplot object",{
 })
 
 test_that("returns expected ggplot object",{
-    expect_equal(length(out96), 9L) # 9 element list
-    expect_equal(names(out96),
-		 c('data', 'layers', 'scales', 'mapping',
-		   'theme', 'coordinates', 'facet', 'plot_env',
-		   'labels'))
+    expect_equal(length(out96), length(ggplot()))
+    expect_equal(names(out96), names(ggplot()))
     expect_equal(names(out96), names(out384))
 })
 


### PR DESCRIPTION
Hello there,

We have been preparing a new release of ggplot2 and during a reverse dependency check, it became apparent that the prospective ggplot2 3.5.0 would break platetools.

Briefly, a few tests expected ggplot objects to satisfy some length and name criterions that no longer hold in the new version. In this PR, these are updated to be aligned with whatever `ggplot()` returns, which works for both the old and new versions.

To test the code changes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```

The release of ggplot2 3.5.0 is scheduled for the 12th of February. The progress of the release can be tracked in https://github.com/tidyverse/ggplot2/issues/5588. We hope that this PR might help platetools get out a fix if necessary.